### PR TITLE
feat(testiny): NL test authoring — Testiny pull + testopus-nl-test skill

### DIFF
--- a/.claude/adr/0002-testiny-nl-authoring.md
+++ b/.claude/adr/0002-testiny-nl-authoring.md
@@ -1,0 +1,98 @@
+# ADR-0002: Testiny-driven natural-language test authoring
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+- **Deciders:** tech-lead, qa-automation-engineer, ai-engineer, backend-engineer
+
+## Context
+
+The team writes test cases in **Testiny** (a web-based test-management platform) as human-language
+descriptions: a precondition, numbered steps, and an expected result. Turning those into executable
+Pytest suites today requires a manual re-typing step that is error-prone and duplicates effort —
+the case exists in two places (Testiny and the Python repo) and drifts over time.
+
+We needed a repeatable, auditable path from a Testiny case to a committed pytest suite that:
+
+1. Does not add a large new runtime dependency to the test framework.
+2. Keeps the framework's layering invariant intact: `core/` must not import AI or LLM libraries.
+3. Produces a deterministic, committed test — not an agentic test runner that calls an LLM at
+   test-execution time.
+4. Reuses the existing Page Object and skill infrastructure rather than duplicating it.
+5. Is traceably linked from the committed test back to the Testiny source case.
+
+## Decision
+
+Implement a two-stage **authoring-time** pipeline:
+
+### Stage 1 — Pull (`tools/testiny`)
+
+A standalone `tools/` package (`python -m tools.testiny pull`) fetches cases from the Testiny
+REST API and normalizes each into a **Markdown + YAML front-matter spec file** under `specs/<app>/`.
+The tool is authoring-time tooling only:
+
+- It lives in `tools/`, outside `core/`, and is **not included in the wheel** (`packages` in
+  `pyproject.toml` lists only `fixtures`, `tests`, `utils`, `core`, `config`).
+- Its only new runtime dependency is `requests`, isolated in a dedicated `[tools]` optional extra
+  so the framework's core install stays light.
+- `TESTINY_API_KEY` is read from the environment (or a local `.env`); it is never logged — the
+  debug path routes through `utils.redact.redact_mapping`, which masks the key.
+- The spec format is a strict 1-to-1 projection of the Testiny data model: front-matter fields map
+  directly to Testiny REST fields (`id`, `_etag`, `project_id`, `title`, `priority`, plus the
+  `cf__app`/`cf__page` custom fields), and the body preserves `precondition_text`, `steps_text`,
+  and `expected_result_text` verbatim as Markdown sections. Only `template: "TEXT"` cases are
+  supported.
+
+### Stage 2 — Generate (`testopus-nl-test` skill)
+
+A Claude Code skill (`.claude/skills/testopus-nl-test/SKILL.md`) reads a spec file **and** the
+Page Object it references, grounds every locator/method/`TEXT_*` constant on the real file (never
+inventing selectors), and produces a class-based pytest suite following the `testopus-web-test`
+conventions.
+
+The skill is **Claude Code as the generator**: it uses the same `code-reviewer` → human → `testopus-run`
+gate that governs every other code change. No `anthropic` SDK is added; the Anthropic SDK remains
+a roadmap item (CLAUDE.md "Toward an AI-Driven QA Framework") for when the first **runtime** AI
+feature lands. The model is in the authoring loop only — the committed output is plain Pytest that
+runs deterministically forever.
+
+### Invariant
+
+**The LLM is in the authoring loop only; it never owns the test verdict.** The deterministic test
+path (Selenium → Page Object → pytest) runs with no AI dependency at all.
+
+## Consequences
+
+- **New files:** `tools/testiny/{__main__,cli,client,normalize}.py`, `specs/<app>/tc-*.md`,
+  `.claude/skills/testopus-nl-test/SKILL.md`.
+- **Dependency change:** `requests>=2.34.2` added to `[project.optional-dependencies].tools`.
+  The `test` Hatch env gains `features = ["test", "tools"]` so the tool's tests (which import
+  `tools.testiny`) have the dependency available.
+- **Layering guard unchanged:** `tests/internal_tests/test_layering.py` scans only `core/`;
+  `tools/` is authoring-time infrastructure, outside the guarded perimeter.
+- **Traceability:** every generated suite carries a docstring linking it to its spec file and
+  Testiny case id, and the spec front-matter carries `source: testiny` + `pulled_at` + `testiny_etag`
+  for provenance.
+- **Custom-field dependency:** `cf__app` and `cf__page` are tenant-specific Testiny field keys.
+  Teams must confirm their own field names and set `--app-field`/`--page-field` accordingly.
+
+## Rejected alternatives
+
+**An `anthropic`-SDK generation pipeline now** — would add a heavy optional dep, require an
+`ANTHROPIC_API_KEY` for authoring, and risk the layering invariant if any AI import leaked into
+`core/`. The SDK is already called out in CLAUDE.md as a roadmap item tied to the *first runtime AI
+feature*. Claude Code (already the development environment) is a simpler, zero-dep generator for
+the authoring step.
+
+**BDD / Gherkin / pytest-bdd** — a third convention layer (Testiny → Gherkin → step definitions →
+test) with its own learning curve and maintenance surface. The existing class-based pytest
+convention is already the project standard; the spec → test mapping is a strict projection,
+not a behavior-framework with ambiguous step matching.
+
+**Runtime / agentic execution** — having the LLM select and run tests at runtime violates the
+"AI never owns the verdict" invariant and requires always-on API access in CI. Deterministic
+committed tests are the correct model.
+
+**Placing the tool in `core/` or `utils/`** — `core/` is the guarded, wheel-shipped framework;
+putting authoring tooling there blurs the boundary and would pull `requests` into the core
+install. `utils/` holds thin framework helpers (`helpers.py`, `redact.py`); a multi-module CLI
+package belongs in a top-level `tools/` namespace.

--- a/.claude/skills/testopus-nl-test/SKILL.md
+++ b/.claude/skills/testopus-nl-test/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: testopus-nl-test
+description: This skill should be used when the user asks to turn a human-language test specification — a Testiny case pulled into a `specs/<app>/*.md` file — into a Testopus pytest suite (e.g. "generate the test for spec tc-1", "build the pytest from this Testiny case", "scaffold tests from the specs"). It reads the spec AND the referenced Page Object, grounds every locator/method/TEXT_* constant on real code (never invents selectors), and composes the testopus-page-object + testopus-web-test skills.
+version: 0.1.0
+---
+
+# Testopus — generate a pytest suite from a human-language spec
+
+Turn a `specs/<app>/tc-*.md` spec (a test case described in human language, usually pulled
+from Testiny with `python -m tools.testiny pull …`) into a class-based pytest suite under
+`tests/ui_tests/web/<app>/`. The reference suite is `tests/ui_tests/web/gasag/test_gasag.py`;
+the reference grounding source is `core/pom/web/gasag/login_page.py`.
+
+**The model is in the *authoring* loop only.** The output is plain, committed pytest that runs
+deterministically forever (Selenium drives the browser, not an LLM). This matches the Testopus
+invariant: *AI augments QA and never owns the test verdict; the deterministic path runs with AI
+off.* This skill does **not** push results back to Testiny, does **not** add the `anthropic`
+SDK, and does **not** execute anything agentically at test time.
+
+## Inputs
+
+1. A spec file `specs/<app>/tc-<id>-*.md` — YAML front-matter (`testiny_id`, `app`, `page`,
+   `severity`, …) + a human-language body (`## Precondition`, `## Steps`, `## Expected Result`).
+2. The Page Object it grounds on: `core/pom/web/<app>/<page>_page.py`, resolved from the
+   `app` + `page` front-matter (e.g. `app: gasag`, `page: login` → `LoginPage`).
+
+## Grounding discipline (the core rule — do this first)
+
+1. **Read the Page Object before writing anything.** Build the allowed vocabulary: the locator
+   constants (`(By.X, "…")` tuples), the `TEXT_*` copy constants, the page-URL constant name,
+   and the snake_case action methods that **actually exist** in that file.
+2. **Reference only symbols that exist.** Every `LoginPage.LOCATOR`, `LoginPage.TEXT_*`, and
+   `page.method()` in the generated test must resolve to a real attribute/method. **Never invent
+   a selector, never guess a method name, never inline a raw selector in the test** (CLAUDE.md
+   hard rule — selectors live only on the page class).
+3. **If the spec needs something the page lacks**, stop — do not fabricate. Either:
+   - add the missing locator / `TEXT_*` / action method via the **`testopus-page-object`** skill
+     (verifying any new Selenium API through **`docs-first`**), then continue; or
+   - if you cannot (e.g. the real selector is unknown), emit the test method with a clear
+     `# BLOCKED: needs LoginPage.<X>` marker and call it out for the human reviewer.
+4. **Copy assertions** use the page's `TEXT_*` constants and the "stable key phrase, not the full
+   localized sentence" convention (e.g. `LoginPage.TEXT_ERROR_KEY_PHRASE`).
+
+## Compose, don't duplicate (DRY)
+
+This skill orchestrates the two existing skills — it adds only the spec→test mapping, grounding,
+and provenance:
+
+- **Page Object layer** → **`testopus-page-object`** owns locator-ladder / `TEXT_*` / snake_case
+  rules. Use it to create or extend the page when the spec needs a missing hook.
+- **Test scaffold** → follow **`testopus-web-test`** exactly: class-based `Test<Name>` suite, an
+  `autouse` config fixture, a per-test page fixture, `@retry` from `core.pom.web.base_page`,
+  `pytest_check` soft assertions, and the registered Allure markers (`feature/story/severity/tag`).
+
+## Spec → test mapping
+
+| Spec | Test |
+|---|---|
+| `## Steps` | ordered page-object **action calls + waits** |
+| `## Expected Result` | assertions — `assert` for the one hard outcome; `check.*` to collect several copy/field checks |
+| `severity` front-matter | `@pytest.mark.severity("<severity>")` |
+| `app` / `title` | `@pytest.mark.feature(...)` / `@pytest.mark.story(...)` (registered marks only) |
+| each distinct expected behavior | its own `test_*` method |
+
+## Provenance (required)
+
+Every generated suite carries a docstring linking it back to the source, so a committed test is
+traceable to its spec and Testiny case:
+
+```python
+class TestLoginInvalidCredentials:
+    """Generated from Testiny case 1 (spec: specs/gasag/tc-1-login.md).
+    Regenerate via `python -m tools.testiny pull` + the testopus-nl-test skill."""
+```
+
+## Generated shape (mirrors `tests/ui_tests/web/gasag/test_gasag.py`)
+
+```python
+import logging
+
+import pytest
+
+from core.pom.web.base_page import retry
+from core.pom.web.gasag.login_page import LoginPage
+
+
+def log_retry(attempt, exception, *args, **kwargs):
+    logging.warning(f"Retry attempt {attempt + 1} due to: {str(exception)}")
+
+
+@pytest.mark.feature("GASAG Login")
+class TestLoginInvalidCredentials:
+    """Generated from Testiny case 1 (spec: specs/gasag/tc-1-login.md)."""
+
+    BASE_URL = None
+    USERNAME = None
+    PASSWORD = None
+
+    @pytest.fixture(autouse=True)
+    def setup_test_suite(self, config):
+        if TestLoginInvalidCredentials.BASE_URL is None:
+            self.BASE_URL = config["configuration"]["gasag"]["web_url"]
+            self.USERNAME = config["configuration"]["gasag"]["username"]
+            self.PASSWORD = config["configuration"]["gasag"]["password"]
+
+    @pytest.fixture
+    def login_page(self, driver):
+        url = f"{self.BASE_URL}/{LoginPage.LOGIN_PAGE_URL}"
+        return LoginPage(driver, url=url)
+
+    @pytest.mark.severity("critical")
+    @pytest.mark.story("Authentication")
+    @retry(retries=3, delay=2, on_retry=log_retry)
+    def test_login_rejects_invalid_credentials(self, login_page):
+        # Steps: enter non-matching credentials and submit (LoginPage.login exists).
+        login_page.login(self.USERNAME, self.PASSWORD)
+        # Expected Result: the "no matching login" key phrase appears (real TEXT_* constant).
+        assert login_page.wait_for_text_present(
+            LoginPage.ERROR_MESSAGE, LoginPage.TEXT_ERROR_KEY_PHRASE
+        )
+```
+
+## Steps
+
+1. Read the spec front-matter; resolve `<app>`/`<page>` to `core/pom/web/<app>/<page>_page.py`.
+2. **Read that Page Object** and build the allowed-symbol vocabulary (grounding rule above).
+3. If the spec needs a missing hook, add it via **`testopus-page-object`** first (or mark
+   `# BLOCKED`).
+4. Generate `tests/ui_tests/web/<app>/test_<name>.py` from the **`testopus-web-test`** template,
+   mapping Steps→actions and Expected Result→assertions, with the provenance docstring.
+5. **Do not commit yet.** Hand the change to the mandatory gate, in order (CLAUDE.md "Before push"):
+   the **`code-reviewer`** agent (Opus 4.8, effort `max`) → human review → run it with the
+   **`testopus-run`** skill (`pytest --collect-only` first to catch marker/import errors cheaply,
+   then `hatch run ui:web`). The run/review gate is what makes grounding enforceable — a fabricated
+   `LoginPage.<X>` fails collection.
+
+## Out of scope (future follow-ups)
+
+Pushing test *results* back to Testiny (TestRun API); an `anthropic`-SDK generation pipeline;
+runtime/agentic execution or locator self-healing. See `.claude/adr/0002-testiny-nl-authoring.md`.

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@
 # (see core/config/config_loader.py). In CI, provide them as repository secrets.
 GASAG_USERNAME=
 GASAG_PASSWORD=
+
+# Testiny test-management REST API key (https://app.testiny.io). Read directly by the
+# `python -m tools.testiny` authoring tool (NOT injected into YAML config) and never logged.
+TESTINY_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,8 +198,9 @@ may differ). This is for unfamiliar or version-sensitive calls, not every edit. 
 
 - **Single source of truth:** all dependencies live in `pyproject.toml` — runtime deps in
   `[project].dependencies`, dev tools in `[project.optional-dependencies].dev`, test-only extras in
-  `.test`, future framework backends (Playwright/Appium) in `.frameworks`. Hatch envs pull these via
-  `features` (no per-env duplication). `docker/Dockerfile` installs with `pip install -e .[test]` —
+  `.test`, authoring-time tooling in `.tools` (`requests`; install with `pip install -e .[tools]`),
+  future framework backends (Playwright/Appium) in `.frameworks`. Hatch envs pull these via
+  `features` (no per-env duplication). `docker/Dockerfile` installs with `pip install -e .[test,tools]` —
   never hand-maintain a second dependency list.
 - **Stay current automatically:** `.github/dependabot.yml` watches `pip` (pyproject), `github-actions`,
   and the `docker` base image weekly. Minor/patch Python bumps batch into one PR; each **major** bump
@@ -232,6 +233,28 @@ may differ). This is for unfamiliar or version-sensitive calls, not every edit. 
   by `tests/internal_tests/test_layering.py`, which AST-scans every module under `core/` and fails
   if it imports `core.ai`, `core.ml`, `core.telemetry`, `core.data`, or `anthropic`.
 
+## Test authoring from Testiny
+
+`tools/testiny` + `specs/` + the `testopus-nl-test` skill form an authoring-time pipeline for
+turning human-language Testiny cases into committed Pytest suites.
+
+**Flow:** `python -m tools.testiny pull --case-id N` fetches cases from the Testiny REST API and
+writes `specs/<app>/tc-<id>-<slug>.md` (Markdown + YAML front-matter). The `testopus-nl-test`
+skill then reads the spec and the referenced Page Object, grounds every locator/method/`TEXT_*`
+constant on real code, and generates a class-based pytest suite. The output goes through the
+standard `code-reviewer` + `testopus-run` gate before commit.
+
+**Key constraints:**
+
+- `tools/` is **authoring-time tooling** — it is outside `core/`, not included in the wheel
+  (`packages` in `pyproject.toml`), and not scanned by `test_layering.py`. The `[tools]` extra
+  (`requests>=2.34.2`) must be installed explicitly: `pip install -e .[tools]`. The `test` Hatch
+  env already includes it.
+- `TESTINY_API_KEY` is read from the environment or a local `.env` (see `.env.example`); it is
+  never logged (masked by `utils.redact.redact_mapping`). Never commit the key.
+- The LLM is in the **authoring loop only** — the committed test runs deterministically with no
+  AI dependency. See `docs/testiny/workflow.md` and `.claude/adr/0002-testiny-nl-authoring.md`.
+
 ## `.claude/` team & tooling
 
 This repo ships a Claude Code toolkit under `.claude/`:
@@ -249,6 +272,7 @@ This repo ships a Claude Code toolkit under `.claude/`:
   antipatterns (+ action items), an improvement/feature roadmap, and best-practices adoption —
   writing three docs to `docs/audit/`. Same agent-teams/fan-out mode detection as `/team-council`.
 - **Skills** (`.claude/skills/`): `testopus-page-object`, `testopus-web-test`, `testopus-run`,
-  `flaky-triage`, `docs-first`.
+  `flaky-triage`, `docs-first`, `testopus-nl-test`.
 - **ADRs** (`.claude/adr/`): architecture decision records. ADR-0001 (`0001-driver-seam.md`) records
-  the `BaseDriver`/`ElementHandle` Protocol seam and driver factory.
+  the `BaseDriver`/`ElementHandle` Protocol seam and driver factory. ADR-0002
+  (`0002-testiny-nl-authoring.md`) records the Testiny-driven natural-language authoring pipeline.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ Conventions for writing page objects and tests — POM locators, the `@retry` de
 flaky web steps, `pytest_check` soft assertions — live in [`CLAUDE.md`](CLAUDE.md);
 `tests/ui_tests/web/gasag/test_gasag.py` is a worked example.
 
+### Generate tests from Testiny (experimental)
+
+Test cases written in [Testiny](https://app.testiny.io) can be pulled into local spec files and
+then turned into committed pytest suites via Claude Code. The tool requires the `[tools]` extra
+(`requests`):
+
+```bash
+pip install -e .[tools]
+# Set TESTINY_API_KEY in .env (copy .env.example)
+
+python -m tools.testiny pull --case-id 1          # writes specs/gasag/tc-1-login.md
+# Then invoke the testopus-nl-test skill to generate the pytest suite,
+# followed by the mandatory code-reviewer + testopus-run gate before committing.
+```
+
+The LLM is in the authoring loop only — the committed output is plain Pytest with no AI dependency
+at runtime. See [`docs/testiny/workflow.md`](docs/testiny/workflow.md) for the full end-to-end guide.
+
 ## Troubleshooting
 
 - **ChromeDriver / Chrome mismatch** — match their versions, or set `CHROMEDRIVER_PATH`. (Docker avoids

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,9 @@ COPY utils ./utils
 COPY config ./config
 COPY tests ./tests
 
-# Install the project plus its "test" extra straight from pyproject.toml.
-RUN pip install --no-cache-dir -e ".[test]"
+# Install the project plus its "test" and "tools" extras straight from pyproject.toml
+# (tools carries `requests`, which the internal tests' Testiny client imports).
+RUN pip install --no-cache-dir -e ".[test,tools]"
 
 # Copy the rest of the code
 COPY . .

--- a/docs/testiny/workflow.md
+++ b/docs/testiny/workflow.md
@@ -1,0 +1,271 @@
+# Testiny-driven test authoring workflow
+
+This document describes the end-to-end flow for turning a human-language test case written in
+[Testiny](https://app.testiny.io) into a committed, deterministic Pytest suite in Testopus.
+
+For the architectural rationale and rejected alternatives see
+[ADR-0002](../../.claude/adr/0002-testiny-nl-authoring.md).
+
+## Overview
+
+```
+QA writes case in Testiny
+        |
+        v
+python -m tools.testiny pull  →  specs/<app>/tc-<id>-<slug>.md
+        |
+        v
+Review spec (locators / page exist?)
+        |
+        v
+testopus-nl-test skill  →  tests/ui_tests/web/<app>/test_<name>.py
+        |
+        v
+code-reviewer (Opus 4.8, effort max)  +  human review
+        |
+        v
+testopus-run skill  (pytest --collect-only, then hatch run ui:web)
+        |
+        v
+commit
+```
+
+The LLM (Claude Code) is in the **authoring** step only. The committed output is plain Pytest that
+runs deterministically with no AI dependency at test-execution time.
+
+## Prerequisites
+
+### Install the tools extra
+
+The pull tool depends on `requests`, which lives in the `[tools]` optional extra:
+
+```bash
+pip install -e .[tools]
+```
+
+When using Hatch the `test` env already includes this extra (`features = ["test", "tools"]`).
+
+### Set `TESTINY_API_KEY`
+
+Copy `.env.example` to `.env` (gitignored) and fill in your Testiny REST API key:
+
+```bash
+cp .env.example .env
+# edit .env: set TESTINY_API_KEY=<your key>
+```
+
+The key is read from `TESTINY_API_KEY` in the environment or the local `.env`; it is never
+written to logs or spec files (debug output is masked by `utils.redact.redact_mapping`).
+In CI, set it as a repository secret.
+
+### Confirm your custom field keys
+
+The tool maps two Testiny custom fields to spec metadata:
+
+| CLI flag | Default | Purpose |
+|---|---|---|
+| `--app-field` | `cf__app` | Testiny custom field holding the app name |
+| `--page-field` | `cf__page` | Testiny custom field holding the page name |
+
+Custom-field keys are **tenant-specific** in Testiny. Verify the exact key names in your Testiny
+project's Settings → Custom Fields and supply `--app-field`/`--page-field` if they differ from
+the defaults.
+
+## Step 1 — Pull cases from Testiny
+
+```
+python -m tools.testiny pull <selector> [options]
+```
+
+Exactly one selector is required:
+
+| Flag | Description |
+|---|---|
+| `--case-id N[,N,…]` | Fetch one or more cases by id |
+| `--folder ID` | Fetch every case in a Testiny folder |
+| `--query '<JSON>'` | Pass a raw Testiny filter object (you own the scope) |
+
+### Common options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--base-url URL` | `https://app.testiny.io/api/v1` | Testiny API base URL |
+| `--project-id ID` | — | Scope `--folder`/`--query` to a project |
+| `--app-field KEY` | `cf__app` | Custom field for the app name |
+| `--page-field KEY` | `cf__page` | Custom field for the page name |
+| `--default-app NAME` | — | Fallback app when the custom field is absent |
+| `--default-page NAME` | — | Fallback page when the custom field is absent |
+| `--out DIR` | `specs` | Output root directory |
+| `--verbose` | off | Enable debug logging (key stays masked) |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | All fetched cases written successfully |
+| 1 | Network / HTTP error from Testiny |
+| 2 | `TESTINY_API_KEY` not set |
+
+### Examples
+
+```bash
+# Pull a single case
+python -m tools.testiny pull --case-id 1
+
+# Pull several cases at once
+python -m tools.testiny pull --case-id 1,2,7
+
+# Pull an entire folder (scoped to project 42)
+python -m tools.testiny pull --folder 9 --project-id 42
+
+# Pull with a custom filter; fall back to gasag/login when custom fields are absent
+python -m tools.testiny pull \
+    --query '{"priority": {"op": "eq", "value": "high"}}' \
+    --default-app gasag --default-page login
+
+# Use non-default custom field keys
+python -m tools.testiny pull \
+    --case-id 5 \
+    --app-field cf__application \
+    --page-field cf__screen
+
+# Verbose mode (the API key is masked in output)
+python -m tools.testiny pull --case-id 1 --verbose
+```
+
+## Step 2 — Review the spec
+
+Each pulled case is written to `specs/<app>/tc-<id>-<slug>.md`. Open the file and verify:
+
+- The `app` and `page` values map to a real Page Object (`core/pom/web/<app>/<page>_page.py`).
+- The precondition, steps, and expected result are complete and unambiguous.
+- The `priority`/`severity` mapping looks correct for your project.
+
+If the Page Object for `app`/`page` does not yet exist, create it first with the
+`testopus-page-object` skill before proceeding.
+
+## Spec format reference
+
+A pulled spec is YAML front-matter followed by a three-section Markdown body:
+
+```markdown
+---
+testiny_id: 1
+testiny_etag: 'W/"abc123"'
+project_id: 42
+title: Login rejects invalid credentials
+app: gasag
+page: login
+priority: high
+severity: critical
+status: draft
+source: testiny
+pulled_at: 2026-06-16T10:30:00Z
+---
+
+# Login rejects invalid credentials
+
+## Precondition
+
+The user is on the GASAG online-service login page (`LoginPage`).
+
+## Steps
+
+1. Enter an e-mail address and a password that do not match any account.
+2. Submit the login form.
+
+## Expected Result
+
+An authentication error is shown (the "no matching login" key phrase) and the user remains
+on the login page.
+```
+
+### Front-matter field mapping
+
+| Spec field | Testiny source |
+|---|---|
+| `testiny_id` | `id` |
+| `testiny_etag` | `_etag` |
+| `project_id` | `project_id` |
+| `title` | `title` |
+| `app` | `cf__app` (or `--default-app`) |
+| `page` | `cf__page` (or `--default-page`) |
+| `priority` | `priority` |
+| `severity` | derived from `priority` (see table below) |
+| `status` | always `draft` |
+| `source` | always `testiny` |
+| `pulled_at` | UTC timestamp of the pull run |
+
+Optional fields (`testiny_etag`, `project_id`, `priority`, `pulled_at`) are omitted from the
+front-matter when the Testiny case does not supply them, so the file stays clean.
+
+### Priority → severity mapping
+
+The severity is written to the spec front-matter and becomes the `@pytest.mark.severity` value
+in the generated test. Mapping is case-insensitive; unknown or missing priority values map to
+`normal`.
+
+| Testiny priority | Allure severity |
+|---|---|
+| highest | blocker |
+| high | critical |
+| medium / normal | normal |
+| low | minor |
+| lowest | trivial |
+| unknown / missing | normal |
+
+### Body sections
+
+| Section | Testiny field |
+|---|---|
+| `## Precondition` | `precondition_text` |
+| `## Steps` | `steps_text` |
+| `## Expected Result` | `expected_result_text` |
+
+All three sections are always present; when Testiny leaves a field blank the section body is
+`_None specified._` so the skill can flag the gap rather than mis-parsing the document.
+
+Only `template: "TEXT"` cases are supported. Step-table templates are out of scope.
+
+## Step 3 — Generate the pytest suite
+
+With a reviewed spec in place, invoke the **`testopus-nl-test`** skill:
+
+```
+/testopus-nl-test specs/gasag/tc-1-login.md
+```
+
+The skill:
+
+1. Reads the spec front-matter to resolve `app`/`page` → `core/pom/web/<app>/<page>_page.py`.
+2. Reads the Page Object and builds the allowed vocabulary (locator constants, `TEXT_*` copy
+   constants, snake_case action methods).
+3. Maps `## Steps` to page-object action calls and `## Expected Result` to assertions, using
+   only symbols that actually exist in the Page Object.
+4. Generates `tests/ui_tests/web/<app>/test_<name>.py` with a provenance docstring linking
+   the test back to its spec and Testiny case id.
+
+If the spec requires a locator or action method that does not yet exist on the Page Object,
+the skill either extends the Page Object via the `testopus-page-object` skill first, or emits
+a `# BLOCKED: needs <PageClass>.<X>` marker for the human reviewer to resolve.
+
+## Step 4 — Review and run
+
+Before committing the generated test, run the mandatory "Before push" gate in order:
+
+1. **Code review** — `code-reviewer` agent (Opus 4.8, effort `max`). A fabricated locator or
+   invented method name will fail pytest collection, making grounding violations mechanically
+   detectable.
+2. **Run** — `testopus-run` skill: `pytest --collect-only` first (catches marker/import errors
+   cheaply), then `hatch run ui:web`.
+3. **Commit** after both pass.
+
+## Out of scope
+
+The following are explicitly not part of this workflow:
+
+- Pushing test **results** back to Testiny (the TestRun API) — a future follow-up.
+- An `anthropic`-SDK generation pipeline at authoring time — roadmap (ADR-0002).
+- Runtime or agentic test execution where an LLM selects or drives tests — the verdict is
+  always owned by the deterministic pytest path.
+- Locator self-healing at test-execution time — roadmap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,13 @@ dev = [
 # Test-only extras on top of the core test deps above.
 test = [
   "pytest-cov>=7.1.0",
-  "requests>=2.34.2",
   "Faker>=40.23.0",
+]
+# Authoring-time tooling deps (the `tools/` package — e.g. `python -m tools.testiny`).
+# Not part of the runtime test path; install with `pip install -e .[tools]`. The test
+# Hatch env pulls this too, because the tool's tests import its `requests`-based client.
+tools = [
+  "requests>=2.34.2",
 ]
 # Future framework backends — declared but not yet wired (see core/drivers/factory.py).
 # Install with `pip install -e .[frameworks]` when implementing the Playwright/Appium seam.
@@ -93,12 +98,12 @@ ignore_missing_imports = true
 features = ["dev"]
 
 [tool.hatch.envs.default.scripts]
-format = "black core fixtures utils config tests"
-lint = "ruff check core fixtures utils config tests"
-typecheck = "mypy core fixtures utils"
+format = "black core fixtures utils config tests tools"
+lint = "ruff check core fixtures utils config tests tools"
+typecheck = "mypy core fixtures utils tools"
 
 [tool.hatch.envs.test]
-features = ["test"]
+features = ["test", "tools"]
 
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:tests}"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,10 @@
 [pytest]
 pythonpath = .
+# The `tools/testiny` namespace starts with "test", so a public symbol such as
+# `testiny_case_to_spec` would match pytest's default `test*` function-collection glob
+# when imported into a test module. Require the `test_` prefix (every suite already uses
+# it) so helpers in that namespace are never mistaken for tests.
+python_functions = test_*
 filterwarnings =
     ignore: .*Argument name-based*. :DeprecationWarning
 log_cli = 1

--- a/specs/gasag/tc-1-login.md
+++ b/specs/gasag/tc-1-login.md
@@ -1,0 +1,30 @@
+---
+# Sample spec checked in as a grounding example (not a live Testiny pull).
+# `python -m tools.testiny pull` writes files in exactly this shape; see
+# docs/testiny/workflow.md and the testopus-nl-test skill.
+testiny_id: 1
+project_id: 42
+title: Login rejects invalid credentials
+app: gasag
+page: login
+priority: high
+severity: critical
+status: draft
+source: testiny
+---
+
+# Login rejects invalid credentials
+
+## Precondition
+
+The user is on the GASAG online-service login page (`LoginPage`).
+
+## Steps
+
+1. Enter an e-mail address and a password that do not match any account.
+2. Submit the login form.
+
+## Expected Result
+
+An authentication error is shown (the "no matching login" key phrase) and the user remains
+on the login page.

--- a/tests/internal_tests/test_testiny_client.py
+++ b/tests/internal_tests/test_testiny_client.py
@@ -1,0 +1,105 @@
+"""Tests for the Testiny client + CLI (tools/testiny/client.py, cli.py).
+
+The network is mocked with pytest-mock — no live Testiny account needed. Verifies the
+request shape (URL + ``X-Api-Key`` header), pagination, that the CLI writes the expected
+spec, and — critically — that ``TESTINY_API_KEY`` never reaches the logs.
+"""
+
+import logging
+
+import pytest
+
+from tools.testiny import cli
+from tools.testiny.client import TestinyClient
+
+API_KEY = "SECRET-KEY-do-not-log"
+
+CASE = {
+    "id": 123,
+    "project_id": 42,
+    "title": "Login rejects invalid credentials",
+    "priority": "high",
+    "template": "TEXT",
+    "precondition_text": "User is on the login page.",
+    "steps_text": "1. Enter a wrong password.\n2. Submit.",
+    "expected_result_text": "An error message is shown.",
+}
+
+
+def _mock_response(mocker, payload):
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return response
+
+
+def test_get_testcase_builds_url_and_sends_api_key(mocker):
+    get = mocker.patch(
+        "tools.testiny.client.requests.get",
+        return_value=_mock_response(mocker, CASE),
+    )
+    client = TestinyClient(API_KEY, "https://app.testiny.io/api/v1")
+    assert client.get_testcase(123) == CASE
+    url = get.call_args.args[0]
+    headers = get.call_args.kwargs["headers"]
+    assert url.endswith("/testcase/123")
+    assert headers["X-Api-Key"] == API_KEY
+
+
+def test_client_requires_api_key():
+    with pytest.raises(ValueError):
+        TestinyClient("")
+
+
+def test_find_paginates(mocker):
+    # First page full (100) -> loop continues; second page short -> loop stops.
+    page1 = {"data": [dict(CASE, id=index) for index in range(100)]}
+    page2 = {"data": [dict(CASE, id=999)]}
+    post = mocker.patch(
+        "tools.testiny.client.requests.post",
+        side_effect=[_mock_response(mocker, page1), _mock_response(mocker, page2)],
+    )
+    client = TestinyClient(API_KEY)
+    cases = client.find({"folder_id": {"op": "eq", "value": 9}})
+    assert len(cases) == 101
+    assert post.call_count == 2
+
+
+def test_cli_pull_writes_spec_and_masks_key(mocker, tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("TESTINY_API_KEY", API_KEY)
+    mocker.patch(
+        "tools.testiny.client.requests.get",
+        return_value=_mock_response(mocker, CASE),
+    )
+    with caplog.at_level(logging.DEBUG):
+        exit_code = cli.main(
+            [
+                "pull",
+                "--case-id",
+                "123",
+                "--default-app",
+                "gasag",
+                "--default-page",
+                "login",
+                "--out",
+                str(tmp_path),
+                "--verbose",
+            ]
+        )
+    assert exit_code == 0
+    specs = list(tmp_path.rglob("*.md"))
+    assert len(specs) == 1
+    content = specs[0].read_text(encoding="utf-8")
+    assert "app: gasag" in content
+    assert "severity: critical" in content
+    # The key must never reach the logs; the masked marker proves redaction ran.
+    assert API_KEY not in caplog.text
+    assert "***REDACTED***" in caplog.text
+
+
+def test_cli_missing_key_returns_2(monkeypatch):
+    monkeypatch.delenv("TESTINY_API_KEY", raising=False)
+    exit_code = cli.main(
+        ["pull", "--case-id", "1", "--default-app", "x", "--default-page", "y"]
+    )
+    assert exit_code == 2

--- a/tests/internal_tests/test_testiny_normalize.py
+++ b/tests/internal_tests/test_testiny_normalize.py
@@ -1,0 +1,178 @@
+"""Pure-logic tests for the Testiny -> spec-Markdown normalizer.
+
+Covers ``tools/testiny/normalize.py`` with no network or filesystem — exercises
+``testiny_case_to_spec``, ``priority_to_severity`` and ``spec_filename`` against canned
+Testiny test-case dicts. Front-matter is asserted by parsing it back with
+``yaml.safe_load`` (robust to YAML formatting); the body by section content.
+"""
+
+import pytest
+import yaml
+
+from tools.testiny.normalize import (
+    SpecValidationError,
+    priority_to_severity,
+    spec_filename,
+    testiny_case_to_spec,
+)
+
+
+def _split_spec(spec_text):
+    """Return ``(front_matter_dict, body_str)`` from a generated spec."""
+    assert spec_text.startswith("---\n")
+    _, front_matter, body = spec_text.split("---\n", 2)
+    return yaml.safe_load(front_matter), body
+
+
+def _full_case():
+    return {
+        "id": 123,
+        "project_id": 42,
+        "title": "Login rejects invalid credentials",
+        "priority": "high",
+        "template": "TEXT",
+        "_etag": 'W/"abc"',
+        "precondition_text": "User is on the login page.",
+        "steps_text": "1. Enter a wrong password.\n2. Submit.",
+        "expected_result_text": "An error message is shown.",
+        "cf__app": "gasag",
+        "cf__page": "login",
+    }
+
+
+def test_full_case_front_matter():
+    spec = testiny_case_to_spec(_full_case(), pulled_at="2026-06-16T00:00:00Z")
+    front, _ = _split_spec(spec)
+    assert front["testiny_id"] == 123
+    assert front["project_id"] == 42
+    assert front["title"] == "Login rejects invalid credentials"
+    assert front["app"] == "gasag"
+    assert front["page"] == "login"
+    assert front["priority"] == "high"
+    assert front["severity"] == "critical"
+    assert front["status"] == "draft"
+    assert front["source"] == "testiny"
+    assert front["pulled_at"] == "2026-06-16T00:00:00Z"
+    assert front["testiny_etag"] == 'W/"abc"'
+
+
+def test_full_case_body_sections():
+    spec = testiny_case_to_spec(_full_case())
+    _, body = _split_spec(spec)
+    assert "# Login rejects invalid credentials" in body
+    assert "## Precondition" in body
+    assert "User is on the login page." in body
+    assert "## Steps" in body
+    assert "1. Enter a wrong password." in body
+    assert "## Expected Result" in body
+    assert "An error message is shown." in body
+
+
+@pytest.mark.parametrize(
+    "priority,expected",
+    [
+        ("highest", "blocker"),
+        ("high", "critical"),
+        ("medium", "normal"),
+        ("normal", "normal"),
+        ("low", "minor"),
+        ("lowest", "trivial"),
+        ("HIGH", "critical"),  # case-insensitive
+        ("weird", "normal"),  # unknown -> normal
+        (None, "normal"),  # missing -> normal
+    ],
+)
+def test_priority_to_severity(priority, expected):
+    assert priority_to_severity(priority) == expected
+
+
+def test_app_page_fall_back_to_defaults():
+    case = _full_case()
+    del case["cf__app"]
+    del case["cf__page"]
+    spec = testiny_case_to_spec(case, default_app="shop", default_page="checkout")
+    front, _ = _split_spec(spec)
+    assert front["app"] == "shop"
+    assert front["page"] == "checkout"
+
+
+def test_custom_field_names_are_configurable():
+    case = _full_case()
+    del case["cf__app"]
+    del case["cf__page"]
+    case["cf__application"] = "gasag"
+    case["cf__screen"] = "login"
+    spec = testiny_case_to_spec(
+        case, app_field="cf__application", page_field="cf__screen"
+    )
+    front, _ = _split_spec(spec)
+    assert front["app"] == "gasag"
+    assert front["page"] == "login"
+
+
+def test_missing_app_without_default_raises():
+    case = _full_case()
+    del case["cf__app"]
+    with pytest.raises(SpecValidationError):
+        testiny_case_to_spec(case)
+
+
+def test_missing_required_field_raises():
+    case = _full_case()
+    del case["title"]
+    with pytest.raises(SpecValidationError):
+        testiny_case_to_spec(case)
+
+
+def test_non_text_template_raises():
+    case = _full_case()
+    case["template"] = "STEPS"
+    with pytest.raises(SpecValidationError):
+        testiny_case_to_spec(case)
+
+
+def test_empty_precondition_renders_placeholder():
+    case = _full_case()
+    case["precondition_text"] = ""
+    spec = testiny_case_to_spec(case)
+    _, body = _split_spec(spec)
+    # Section header kept for a stable three-section body the skill can rely on.
+    assert "## Precondition" in body
+
+
+def test_markdown_in_text_is_preserved_verbatim():
+    case = _full_case()
+    case["steps_text"] = "1. Click **Login**\n2. See `error`"
+    spec = testiny_case_to_spec(case)
+    _, body = _split_spec(spec)
+    assert "**Login**" in body
+    assert "`error`" in body
+
+
+def test_optional_fields_omitted_when_absent():
+    case = _full_case()
+    del case["_etag"]
+    del case["priority"]
+    spec = testiny_case_to_spec(case)
+    front, _ = _split_spec(spec)
+    assert "testiny_etag" not in front
+    assert "priority" not in front
+    assert front["severity"] == "normal"  # missing priority still yields a severity
+
+
+def test_spec_filename_is_deterministic_slug():
+    case = {"id": 5, "title": "Login rejects invalid credentials!"}
+    assert spec_filename(case) == "tc-5-login-rejects-invalid-credentials.md"
+
+
+def test_spec_filename_folds_unicode():
+    case = {"id": 7, "title": "Anmelden möglich"}
+    assert spec_filename(case) == "tc-7-anmelden-moglich.md"
+
+
+def test_spec_filename_caps_length():
+    case = {"id": 9, "title": "x" * 200}
+    name = spec_filename(case)
+    assert name.startswith("tc-9-")
+    assert name.endswith(".md")
+    assert len(name) < 80

--- a/tools/testiny/__main__.py
+++ b/tools/testiny/__main__.py
@@ -1,0 +1,8 @@
+"""Make ``python -m tools.testiny`` run the pull CLI."""
+
+import sys
+
+from tools.testiny.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/testiny/cli.py
+++ b/tools/testiny/cli.py
@@ -1,0 +1,163 @@
+"""CLI for pulling Testiny test cases into spec files (``python -m tools.testiny``).
+
+Authoring-time tooling — NOT part of the runtime test path. Fetches cases via the
+Testiny REST API, normalizes each into the Markdown + front-matter spec format, and
+writes them under ``specs/<app>/``. The API key comes from ``TESTINY_API_KEY``
+(environment or a local ``.env``) and is never logged. After pulling, generate the
+pytest suite from a spec with the ``testopus-nl-test`` skill (which grounds the test
+on the real Page Object).
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from tools.testiny.client import DEFAULT_BASE_URL, TestinyClient
+from tools.testiny.normalize import (
+    SpecValidationError,
+    resolve_app,
+    spec_filename,
+    testiny_case_to_spec,
+)
+from utils.redact import redact_mapping
+
+logger = logging.getLogger("tools.testiny")
+
+API_KEY_ENV = "TESTINY_API_KEY"
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.testiny",
+        description="Pull Testiny test cases into local Markdown spec files.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    pull = subcommands.add_parser(
+        "pull", help="Fetch test case(s) and write specs/<app>/tc-*.md"
+    )
+    selector = pull.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--case-id", help="Comma-separated Testiny test-case id(s).")
+    selector.add_argument("--folder", help="Pull every case in a Testiny folder id.")
+    selector.add_argument(
+        "--query",
+        help="Raw Testiny filter as JSON (you scope it; --project-id is ignored).",
+    )
+    pull.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    pull.add_argument(
+        "--project-id", help="Testiny project id (scopes --folder / --query)."
+    )
+    pull.add_argument(
+        "--app-field", default="cf__app", help="Custom field holding the app name."
+    )
+    pull.add_argument(
+        "--page-field", default="cf__page", help="Custom field holding the page name."
+    )
+    pull.add_argument("--default-app", help="App used when --app-field is absent.")
+    pull.add_argument("--default-page", help="Page used when --page-field is absent.")
+    pull.add_argument(
+        "--out", default="specs", help="Output root directory (default: specs/)."
+    )
+    pull.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging (the key stays masked).",
+    )
+    return parser
+
+
+def _as_int(value):
+    """Best-effort int coercion; leave non-numeric values untouched."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _fetch_cases(client, args):
+    """Resolve the selector flags into a list of Testiny case dicts."""
+    if args.case_id:
+        ids = [part.strip() for part in args.case_id.split(",") if part.strip()]
+        return [client.get_testcase(case_id) for case_id in ids]
+    if args.folder:
+        filter_obj = {"folder_id": {"op": "eq", "value": _as_int(args.folder)}}
+        if args.project_id:
+            filter_obj["project_id"] = {"op": "eq", "value": _as_int(args.project_id)}
+        return client.find(filter_obj)
+    return client.find(json.loads(args.query))
+
+
+def main(argv=None):
+    """Entry point. Returns an exit code (0 ok, 1 fetch error, 2 missing key)."""
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    load_dotenv()
+    api_key = os.environ.get(API_KEY_ENV)
+    if not api_key:
+        logger.error("%s not set — see .env.example", API_KEY_ENV)
+        return 2
+
+    # Effective config is safe to log: redact_mapping() masks the api_key value (the
+    # "api_key" hint is in utils.redact._SECRET_KEY_HINTS) — one shared helper so
+    # secret handling never diverges.
+    logger.debug(
+        "Testiny pull config: %s",
+        redact_mapping(
+            {
+                "base_url": args.base_url,
+                "project_id": args.project_id,
+                "api_key": api_key,
+                "app_field": args.app_field,
+                "page_field": args.page_field,
+                "out": args.out,
+            }
+        ),
+    )
+
+    client = TestinyClient(api_key, args.base_url)
+    try:
+        cases = _fetch_cases(client, args)
+    except (requests.RequestException, ValueError) as exc:
+        # Surface the failure without leaking the key (it lives in headers, not exc).
+        logger.error("Failed to fetch from Testiny: %s", exc)
+        return 1
+
+    pulled_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    out_root = Path(args.out)
+    written = 0
+    for case in cases:
+        try:
+            spec = testiny_case_to_spec(
+                case,
+                app_field=args.app_field,
+                page_field=args.page_field,
+                default_app=args.default_app,
+                default_page=args.default_page,
+                pulled_at=pulled_at,
+            )
+        except SpecValidationError as exc:
+            logger.warning("Skipping case %s: %s", case.get("id"), exc)
+            continue
+        app = resolve_app(case, args.app_field, args.default_app)
+        destination = out_root / app / spec_filename(case)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(spec, encoding="utf-8")
+        written += 1
+        logger.info("Wrote %s", destination)
+
+    logger.info("Done: %d spec(s) written under %s/", written, out_root)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module-level convenience
+    sys.exit(main())

--- a/tools/testiny/client.py
+++ b/tools/testiny/client.py
@@ -1,0 +1,82 @@
+"""Thin HTTP client for the Testiny REST API (https://app.testiny.io/api/v1/).
+
+The ONLY network code under ``tools/testiny`` — kept minimal so the CLI and the pure
+normalizer stay testable (tests mock ``requests`` rather than hitting the network).
+The API key is sent only in the ``X-Api-Key`` header and is never logged; the CLI
+routes any debug output through ``utils.redact``.
+"""
+
+import requests
+
+DEFAULT_BASE_URL = "https://app.testiny.io/api/v1"
+_DEFAULT_TIMEOUT = 30
+_DEFAULT_PAGE_SIZE = 100
+
+
+class TestinyClient:
+    """Minimal Testiny REST client — fetch test cases by id or by filter."""
+
+    # Name starts with "Test", matching pytest's default class-collection glob; opt out
+    # so pytest never tries to collect this client as a test suite.
+    __test__ = False
+
+    def __init__(self, api_key, base_url=DEFAULT_BASE_URL, *, timeout=_DEFAULT_TIMEOUT):
+        if not api_key:
+            raise ValueError("api_key is required")
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._headers = {"X-Api-Key": api_key, "Accept": "application/json"}
+
+    def get_testcase(self, case_id):
+        """Return a single test case (``GET /testcase/:id``)."""
+        response = requests.get(
+            f"{self._base_url}/testcase/{case_id}",
+            headers=self._headers,
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def find(self, filter_obj=None, *, page_size=_DEFAULT_PAGE_SIZE):
+        """Return every case matching a filter (``POST /testcase/find``), across pages.
+
+        :param filter_obj: A Testiny filter object, e.g.
+            ``{"folder_id": {"op": "eq", "value": 9}}``. ``None`` fetches all cases.
+        :param page_size: Page size for the ``limit``/``offset`` pagination loop.
+        """
+        results = []
+        offset = 0
+        while True:
+            body = {"limit": page_size, "offset": offset}
+            if filter_obj:
+                body["filter"] = filter_obj
+            response = requests.post(
+                f"{self._base_url}/testcase/find",
+                json=body,
+                headers=self._headers,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+            page = _extract_cases(response.json())
+            results.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+        return results
+
+
+def _extract_cases(payload):
+    """Pull the list of cases out of a Testiny ``find`` response.
+
+    Defensive about the envelope — tolerates ``{"data": [...]}``, ``{"items": [...]}``,
+    ``{"results": [...]}`` or a bare list — so a minor API-shape change does not break
+    the pull. Confirm the exact envelope against your Testiny instance.
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("data", "items", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    return []

--- a/tools/testiny/normalize.py
+++ b/tools/testiny/normalize.py
@@ -1,0 +1,171 @@
+"""Pure logic: convert a Testiny test-case dict into a Testopus spec-Markdown string.
+
+No network or filesystem here (those live in ``tools/testiny/client.py`` and
+``cli.py``) so this module is unit-tested in isolation. The output is the
+"Markdown + front-matter" spec format consumed by the ``testopus-nl-test`` skill;
+the fields map 1:1 onto the Testiny REST data model (``title`` /
+``precondition_text`` / ``steps_text`` / ``expected_result_text`` / ``priority`` +
+custom fields). See ``docs/testiny/workflow.md`` and
+``.claude/adr/0002-testiny-nl-authoring.md``.
+"""
+
+import re
+import unicodedata
+
+import yaml
+
+# Testiny priority -> Allure severity (the set pytest.ini registers: blocker/critical/
+# normal/minor/trivial). Best-effort and case-insensitive; unknown/missing -> "normal".
+# NOTE: confirm the exact priority vocabulary of your Testiny project and adjust here;
+# this table is the single source of truth shared by the tool and the skill.
+_PRIORITY_TO_SEVERITY = {
+    "highest": "blocker",
+    "high": "critical",
+    "medium": "normal",
+    "normal": "normal",
+    "low": "minor",
+    "lowest": "trivial",
+}
+_DEFAULT_SEVERITY = "normal"
+
+# Placeholder so every spec keeps a stable three-section body even when Testiny leaves
+# a field blank — the skill can then flag the gap instead of mis-parsing a section.
+_EMPTY_SECTION = "_None specified._"
+
+_SLUG_MAX_LEN = 50
+
+
+class SpecValidationError(ValueError):
+    """Raised when a Testiny case cannot become a valid spec — a missing required
+    field, an unsupported (non-TEXT) template, or an app/page that cannot be
+    resolved."""
+
+
+def priority_to_severity(priority):
+    """Map a Testiny priority to an Allure severity (unknown/None -> ``normal``)."""
+    if priority is None:
+        return _DEFAULT_SEVERITY
+    return _PRIORITY_TO_SEVERITY.get(str(priority).strip().lower(), _DEFAULT_SEVERITY)
+
+
+def _slugify(text):
+    """Lowercase ASCII slug: accent-folded, non-alphanumerics collapsed to hyphens."""
+    folded = (
+        unicodedata.normalize("NFKD", str(text))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    slug = "-".join(re.findall(r"[a-z0-9]+", folded))
+    if len(slug) > _SLUG_MAX_LEN:
+        slug = slug[:_SLUG_MAX_LEN].rstrip("-")
+    return slug or "case"
+
+
+def spec_filename(case):
+    """Deterministic ``tc-<id>-<slug>.md`` filename for a Testiny case."""
+    case_id = case.get("id")
+    if case_id is None:
+        raise SpecValidationError("Testiny case is missing required field 'id'.")
+    return f"tc-{case_id}-{_slugify(case.get('title', ''))}.md"
+
+
+def _require(case, field):
+    """Return ``case[field]`` or raise if absent/blank."""
+    value = case.get(field)
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise SpecValidationError(f"Testiny case is missing required field '{field}'.")
+    return value
+
+
+def _section(text):
+    """Section body verbatim, or a placeholder when Testiny left the field empty."""
+    if text is None:
+        return _EMPTY_SECTION
+    return str(text).strip() or _EMPTY_SECTION
+
+
+def _drop_none(mapping):
+    """Drop keys whose value is ``None`` (keeps the front-matter clean and ordered)."""
+    return {key: value for key, value in mapping.items() if value is not None}
+
+
+def resolve_app(case, app_field="cf__app", default_app=None):
+    """Resolve the app name from the case's custom field, falling back to a default.
+
+    Shared by the normalizer and the CLI so the spec's ``app`` front-matter and the
+    ``specs/<app>/`` destination path can never drift.
+    """
+    return case.get(app_field) or default_app
+
+
+def testiny_case_to_spec(
+    case,
+    *,
+    app_field="cf__app",
+    page_field="cf__page",
+    default_app=None,
+    default_page=None,
+    pulled_at=None,
+):
+    """Render a Testiny test-case dict as a spec-Markdown string.
+
+    :param case: A Testiny test-case object (as returned by ``GET /testcase/:id``).
+    :param app_field: Custom-field key holding the app name (default ``cf__app``).
+    :param page_field: Custom-field key holding the page name (default ``cf__page``).
+    :param default_app: Fallback app when the custom field is absent.
+    :param default_page: Fallback page when the custom field is absent.
+    :param pulled_at: Optional ISO timestamp written to the front-matter (provenance).
+    :return: The spec as Markdown (YAML front-matter + Precondition/Steps/Expected).
+    :raises SpecValidationError: On a missing required field, a non-TEXT template, or an
+        unresolved app/page.
+    """
+    template = case.get("template", "TEXT")
+    if str(template).upper() != "TEXT":
+        raise SpecValidationError(
+            f"Unsupported Testiny template '{template}'; only TEXT cases are supported "
+            "(step-table templates are out of scope)."
+        )
+
+    case_id = _require(case, "id")
+    title = _require(case, "title")
+    app = resolve_app(case, app_field, default_app)
+    page = case.get(page_field) or default_page
+    if not app:
+        raise SpecValidationError(
+            f"Cannot resolve app: custom field '{app_field}' is absent and no "
+            "--default-app was given."
+        )
+    if not page:
+        raise SpecValidationError(
+            f"Cannot resolve page: custom field '{page_field}' is absent and no "
+            "--default-page was given."
+        )
+
+    priority = case.get("priority")
+    front = _drop_none(
+        {
+            "testiny_id": case_id,
+            "testiny_etag": case.get("_etag"),
+            "project_id": case.get("project_id"),
+            "title": title,
+            "app": app,
+            "page": page,
+            "priority": priority,
+            "severity": priority_to_severity(priority),
+            "status": "draft",
+            "source": "testiny",
+            "pulled_at": pulled_at or None,
+        }
+    )
+    front_matter = yaml.safe_dump(
+        front, sort_keys=False, allow_unicode=True, width=4096
+    )
+
+    body = (
+        f"# {title}\n\n"
+        f"## Precondition\n\n{_section(case.get('precondition_text'))}\n\n"
+        f"## Steps\n\n{_section(case.get('steps_text'))}\n\n"
+        f"## Expected Result\n\n{_section(case.get('expected_result_text'))}\n"
+    )
+    return f"---\n{front_matter}---\n\n{body}"


### PR DESCRIPTION
Add an authoring-time pipeline that turns human-language Testiny test cases into committed, deterministic pytest suites.

- tools/testiny: `python -m tools.testiny pull` fetches cases via the Testiny REST API (X-Api-Key) and normalizes each into specs/<app>/tc-<id>-<slug>.md (Markdown + YAML front-matter, 1:1 with the Testiny data model). The pure normalizer is unit-tested; client/CLI are thin I/O. TESTINY_API_KEY is read from env/.env and never logged (masked via utils.redact.redact_mapping).
- testopus-nl-test skill: reads a spec + the referenced Page Object, grounds every locator/method/TEXT_* constant on real code (never invents selectors), composes the page-object/web-test skills, and hands off to the code-reviewer + testopus-run gate. Sample spec under specs/gasag/.
- requests isolated in a new [tools] optional extra (not core deps); tools/ lives outside core/, stays out of the wheel, and is untouched by the layering guard. Docker installs .[test,tools].
- pytest.ini: python_functions = test_* — the "testiny"/"Testiny" namespace collides with pytest's default test*/Test* collection globs; TestinyClient also opts out via __test__ = False.
- Docs: ADR-0002, docs/testiny/workflow.md, README + CLAUDE.md.

The LLM is in the authoring loop only; the committed test runs deterministically with no AI dependency. Out of scope: results push-back to Testiny, an anthropic SDK pipeline, runtime/agentic execution.