### PR TITLE
fix(ci): give the Docker container a writable HOME so Chrome can start

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - PYTHONPATH=/app
       - DOCKER_ENV=true
       - PYTEST_ADDOPTS=--verbose
+      # The container runs as the arbitrary host UID above, which has no /etc/passwd entry
+      # and therefore no writable HOME. Chrome then can't create its profile and exits
+      # ("session not created: Chrome instance exited"). Point HOME at a writable dir.
+      - HOME=/tmp
     # Run with appropriate flags for Allure reporting and JUnit XML output
     command: --verbose -vv --alluredir=/app/reports/allure-results --html=/app/reports/html/report.html --self-contained-html --junitxml=/app/reports/junit/report.xml /app/tests
     shm_size: 2gb  


### PR DESCRIPTION
The compose service runs as the arbitrary host UID (`user: ${TESTOPUS_UID}`), which has no /etc/passwd entry and thus no writable HOME. Chrome then cannot create its profile and exits at session start ("session not created: Chrome instance exited"), erroring every web UI test in CI. This is pre-existing — the old gasag suite errored the same way (12 errors) once the container switched to running as the host UID.

Set HOME=/tmp in docker-compose so Chrome has a writable home. Reproduced the exact error locally with an unwritable HOME, then confirmed the fix (the Toolshop web suite passes 5/5 headless).